### PR TITLE
ft: support IDEA's debugger agent for AnsiLevel.TRUECOLOR

### DIFF
--- a/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppInternal.jvm.kt
+++ b/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppInternal.jvm.kt
@@ -52,7 +52,7 @@ internal actual fun getEnv(key: String): String? = System.getenv(key)
 internal actual fun runningInIdeaJavaAgent() = try {
     val bean = ManagementFactory.getRuntimeMXBean()
     val jvmArgs = bean.inputArguments
-    jvmArgs.any { it.startsWith("-javaagent") && "idea_rt.jar" in it }
+    jvmArgs.any { it.startsWith("-javaagent") && ("idea_rt.jar" in it || "debugger-agent.jar" in it) }
 } catch (e: Throwable) {
     false
 }


### PR DESCRIPTION
IDEA's debugger supports colors, but the terminal auto-detect only looks for the runtime(?) agent, named `idea_rt.jar`. A different agent is used for debugging, namely `debugger-agent.jar`. I added this to Intellij JVM arg detection code.